### PR TITLE
mark all Package attributes as properties

### DIFF
--- a/tests/test_repomd.py
+++ b/tests/test_repomd.py
@@ -1,4 +1,5 @@
 from copy import copy
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -95,8 +96,21 @@ def test_iter(repo):
 def test_package(chicken):
     assert repr(chicken) == '<Package: "chicken-2.2.10-1.fc27.noarch">'
     assert chicken.name == 'chicken'
+    assert chicken.arch == 'noarch'
+    assert chicken.summary == 'Chicken'
+    assert chicken.description == 'Chicken.'
+    assert chicken.packager == 'Carl'
+    assert chicken.url == 'https://example.com/chicken'
+    assert chicken.license == 'BBQ'
+    assert chicken.vendor == "Carl's BBQ"
+    assert chicken.sourcerpm == 'chicken-2.2.10-1.fc27.src.rpm'
     assert chicken.epoch == '0'
+    assert chicken.version == '2.2.10'
+    assert chicken.release == '1.fc27'
+    assert chicken.build_time == datetime.fromtimestamp(1525208602)
+    assert chicken.location == 'chicken-2.2.10-1.fc27.noarch.rpm'
     assert chicken.nevra == 'chicken-2.2.10-1.fc27.noarch'
+    assert chicken.nevra_tuple == ('chicken', '0', '2.2.10', '1.fc27', 'noarch')
     assert chicken.nevr == 'chicken-2.2.10-1.fc27'
     assert chicken.nvr == 'chicken-2.2.10-1.fc27'
     assert chicken.vr == '2.2.10-1.fc27'
@@ -105,23 +119,24 @@ def test_package(chicken):
 def test_package_with_epoch(brisket):
     assert repr(brisket) == '<Package: "brisket-1:5.1.1-1.fc27.noarch">'
     assert brisket.name == 'brisket'
+    assert brisket.arch == 'noarch'
+    assert brisket.summary == 'Brisket'
+    assert brisket.description == 'Brisket.'
+    assert brisket.packager == 'Carl'
+    assert brisket.url == 'https://example.com/brisket'
+    assert brisket.license == 'BBQ'
+    assert brisket.vendor == "Carl's BBQ"
+    assert brisket.sourcerpm == 'brisket-5.1.1-1.fc27.src.rpm'
     assert brisket.epoch == '1'
+    assert brisket.version == '5.1.1'
+    assert brisket.release == '1.fc27'
+    assert brisket.build_time == datetime.fromtimestamp(1525208602)
+    assert brisket.location == 'brisket-5.1.1-1.fc27.noarch.rpm'
     assert brisket.nevra == 'brisket-1:5.1.1-1.fc27.noarch'
+    assert brisket.nevra_tuple == ('brisket', '1', '5.1.1', '1.fc27', 'noarch')
     assert brisket.nevr == 'brisket-1:5.1.1-1.fc27'
     assert brisket.nvr == 'brisket-5.1.1-1.fc27'
     assert brisket.vr == '5.1.1-1.fc27'
-
-
-@pytest.mark.parametrize('attr', repomd.Package.__slots__)
-def test_package_attrs_cannot_be_changed(brisket, attr):
-    with pytest.raises(AttributeError):
-        setattr(brisket, attr, 'new value')
-
-
-@pytest.mark.parametrize('attr', repomd.Package.__slots__)
-def test_package_attrs_cannot_be_deleted(brisket, attr):
-    with pytest.raises(AttributeError):
-        delattr(brisket, attr)
 
 
 def test_package_equals_its_copy(chicken):


### PR DESCRIPTION
After merging #2 (thanks @hroncok!), I thought a bit more about how this modules stores and retrieves `Package` attributes.  Currently (both before and after #2) most of the attributes were stored during `__init__` (except for ones that depend on other attributes, such as `nevra`).  The package metadata `Element` (`lxml.etree._Element`) itself is not stored in the `Package`.  With this setup, the module needs custom `__setattr__`, `__delattr__`, and `__copy__` methods to achieve immutability.  Additionally, this setup means all the xml lookups happen on `Package` initialization.

Python natively supports read-only attributes with the `@property` decorator.  In order to make use of that for every attribute, the package metadata `Element` must be stored in the `Package`, so property methods can look up the information they need to return.  Initially I didn't want to do it that way, to keep the `Package` instances smaller.  However, after thinking things through, I think that that approach would be better.  There would no longer be a need for custom `__setattr__`, `__delattr__`, and `__copy__` methods.  It would also speed up `Package` initialization, because the xml lookups would be delayed until you ask for a specific attribute.  I think in most cases that would be better, since a user probably only cares about a few attributes, not all of them.

@hroncok I'd love your feedback on this change.