### PR TITLE
Add mirrorlist support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setuptools.setup(
     # markdown content type
     setup_requires=['setuptools>=38.6.0'],
     install_requires=[
-        'defusedxml',
         'lxml',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,7 @@ setuptools.setup(
     python_requires='>=3.6',
     # markdown content type
     setup_requires=['setuptools>=38.6.0'],
-    install_requires=[
-        'lxml',
-    ],
+    install_requires=[],
     extras_require={
         'test': [
             'pytest',

--- a/source/repomd.py
+++ b/source/repomd.py
@@ -1,7 +1,7 @@
 import datetime
 import gzip
 import io
-import defusedxml.lxml
+import lxml
 import pathlib
 import urllib.request
 import urllib.parse
@@ -45,7 +45,7 @@ def _load_repomd(base, path):
     # download and parse repomd.xml
     try:
         with urllib.request.urlopen(repomd_url) as response:
-            repomd_xml = defusedxml.lxml.fromstring(response.read())
+            repomd_xml = lxml.etree.fromstring(response.read())
     except urllib.error.HTTPError as e:
         if e.code == 404:
             raise NotRepoException(f'{repomd_url} does not exist') from None
@@ -92,7 +92,7 @@ def load(baseurl):
     with urllib.request.urlopen(primary_url) as response:
         with io.BytesIO(response.read()) as compressed:
             with gzip.GzipFile(fileobj=compressed) as uncompressed:
-                metadata = defusedxml.lxml.fromstring(uncompressed.read())
+                metadata = lxml.etree.fromstring(uncompressed.read())
 
     return Repo(baseurl, metadata)
 

--- a/source/repomd.py
+++ b/source/repomd.py
@@ -1,10 +1,10 @@
 import datetime
 import gzip
 import io
-import lxml
 import pathlib
 import urllib.request
 import urllib.parse
+import xml.etree.ElementTree as ET
 
 
 _ns = {
@@ -45,7 +45,7 @@ def _load_repomd(base, path):
     # download and parse repomd.xml
     try:
         with urllib.request.urlopen(repomd_url) as response:
-            repomd_xml = lxml.etree.fromstring(response.read())
+            repomd_xml = ET.fromstring(response.read())
     except urllib.error.HTTPError as e:
         if e.code == 404:
             raise NotRepoException(f'{repomd_url} does not exist') from None
@@ -92,7 +92,7 @@ def load(baseurl):
     with urllib.request.urlopen(primary_url) as response:
         with io.BytesIO(response.read()) as compressed:
             with gzip.GzipFile(fileobj=compressed) as uncompressed:
-                metadata = lxml.etree.fromstring(uncompressed.read())
+                metadata = ET.fromstring(uncompressed.read())
 
     return Repo(baseurl, metadata)
 

--- a/tests/test_repomd.py
+++ b/tests/test_repomd.py
@@ -1,11 +1,10 @@
 import copy
 import datetime
-import lxml
 import pathlib
 import unittest.mock
 import urllib
+import xml.etree.ElementTree as ET
 
-import lxml.etree
 import pytest
 
 import repomd
@@ -148,7 +147,7 @@ def test_load_fail_mirrorlist(mock_one, mock_two):
 def test_load_fallback_mirrorlist(mock_one, mock_two, mock_three):
     repo, primary = load_test_repodata('tests/data/repo')
     f1 = Exception
-    f2 = lxml.etree.fromstring(repo)
+    f2 = ET.fromstring(repo)
 
     mock_one.side_effect = (repomd.NotRepoException, f1, f2)
 
@@ -163,7 +162,7 @@ def test_load_fallback_mirrorlist(mock_one, mock_two, mock_three):
 
 def test_repo(repo):
     assert repo.baseurl == 'https://example.com'
-    assert isinstance(repo._metadata, lxml.etree._Element)
+    assert isinstance(repo._metadata, ET.Element)
 
 
 def test_repo_repr(repo):

--- a/tests/test_repomd.py
+++ b/tests/test_repomd.py
@@ -1,6 +1,6 @@
 import copy
 import datetime
-import defusedxml.lxml
+import lxml
 import pathlib
 import unittest.mock
 import urllib
@@ -148,7 +148,7 @@ def test_load_fail_mirrorlist(mock_one, mock_two):
 def test_load_fallback_mirrorlist(mock_one, mock_two, mock_three):
     repo, primary = load_test_repodata('tests/data/repo')
     f1 = Exception
-    f2 = defusedxml.lxml.fromstring(repo)
+    f2 = lxml.etree.fromstring(repo)
 
     mock_one.side_effect = (repomd.NotRepoException, f1, f2)
 


### PR DESCRIPTION
This patch adds mirrorlist support by introducing the
NotRepoException that is thrown when the HTTP call to
get the repomd.xml file returns 404.

The logic in load() is still the same, it first tries
the direct supplied URL then falls back trying to do
a call to the URL and parsing a list of HTTP URLs like
this mirrorlist [1].

It then loops through those URLs until it successfully
can grab a repomd.xml file.

This doesn't change any API for the library and has
complete test coverage.

[1] http://mirrorlist.centos.org/?repo=os&arch=x86_64&release=7