### PR TITLE
Fix cert verify failed

### DIFF
--- a/source/repomd.py
+++ b/source/repomd.py
@@ -6,6 +6,13 @@ import pathlib
 import urllib.request
 import urllib.parse
 
+try:
+    import ssl
+    import certifi
+    ssl_context = ssl.create_default_context(cafile=certifi.where())
+except ImportError:
+    ssl_context = None
+
 
 _ns = {
     'common': 'http://linux.duke.edu/metadata/common',
@@ -24,7 +31,7 @@ def load(baseurl):
     repomd_url = base._replace(path=str(repomd_path)).geturl()
 
     # download and parse repomd.xml
-    with urllib.request.urlopen(repomd_url) as response:
+    with urllib.request.urlopen(repomd_url, context=ssl_context) as response:
         repomd_xml = defusedxml.lxml.fromstring(response.read())
 
     # determine the location of *primary.xml.gz
@@ -33,7 +40,7 @@ def load(baseurl):
     primary_url = base._replace(path=str(primary_path)).geturl()
 
     # download and parse *-primary.xml
-    with urllib.request.urlopen(primary_url) as response:
+    with urllib.request.urlopen(primary_url, context=ssl_context) as response:
         with io.BytesIO(response.read()) as compressed:
             with gzip.GzipFile(fileobj=compressed) as uncompressed:
                 metadata = defusedxml.lxml.fromstring(uncompressed.read())


### PR DESCRIPTION
This patch exploits the root CA certificates provided by the [certifi](https://pypi.org/project/certifi/) package (if it is present in the system).

This fixs an error like the following when calling `repomd` on macOS or inside minimal Docker images:
```
<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)>
```